### PR TITLE
Better support building with clang & on macOS

### DIFF
--- a/source/explore-index.cpp
+++ b/source/explore-index.cpp
@@ -35,8 +35,8 @@ static void walk(IndexReader const& reader, off_t node, int64_t count,
 
   for (size_t i = 0; i < children.size(); ++i) {
     sofar->push_back(children[i].ch);
-    printf("%s (%" PRId64 ") @%zd\n", sofar->c_str(),
-        children[i].count, children[i].next);
+    printf("%s (%" PRId64 ") @%lld\n", sofar->c_str(),
+        children[i].count, static_cast<long long>(children[i].next));
     walk(reader, children[i].next, children[i].count, path, depth - 1, sofar);
     sofar->resize(sofar->size() - 1);
   }
@@ -56,7 +56,8 @@ int main(int argc, char *argv[]) {
 
   IndexReader reader(input);
 
-  printf("Root (%" PRId64 ") @%zd\n", reader.count(), reader.root());
+  printf("Root (%" PRId64 ") @%lld\n", reader.count(),
+      static_cast<long long>(reader.root()));
 
   int depth = strlen(argv[2]);
   if (argc > 3) {

--- a/source/index-reader.cpp
+++ b/source/index-reader.cpp
@@ -115,6 +115,7 @@ int IndexReader::children(off_t n, int64_t count,
 }
 
 void IndexReader::fail(off_t n, const char* message) const {
-  fprintf(stderr, "error: pos %zd = 0x%02x: %s\n", n, data[n], message);
+  fprintf(stderr, "error: pos %lld = 0x%02x: %s\n", static_cast<long long>(n),
+      data[n], message);
   exit(1);
 }

--- a/source/make-index.cpp
+++ b/source/make-index.cpp
@@ -43,8 +43,9 @@ static void do_line(char const* line, std::vector<string>* out) {
 
 static void write_index(char const* prefix, int num,
                         std::vector<string>* chains) {
-  char filename[strlen(prefix) + 32];
-  sprintf(filename, "%s.%05d.index", prefix, num);
+  size_t buf_len = strlen(prefix) + 32;
+  char filename[buf_len];
+  snprintf(filename, buf_len, "%s.%05d.index", prefix, num);
   FILE *fp = fopen(filename, "w");
   if (fp == NULL) {
     fprintf(stderr, "error: can't open \"%s\"\n", filename);

--- a/source/meson.build
+++ b/source/meson.build
@@ -8,15 +8,27 @@ project(
   ],
 )
 
-add_project_arguments(
-  # Disable warnings that openfst headers trigger
-  '-Wno-dangling-pointer',
+# Disable warnings that openfst headers trigger
+if meson.get_compiler('cpp').get_id() == 'clang'
+  # clang-only args
+  extra_toolchain_args = ['-Wno-deprecated-copy']
+else
+  # gcc-only args
+  extra_toolchain_args = [
+    '-Wno-dangling-pointer',
+    '-Wno-missing-template-keyword',
+  ]
+endif
+project_args = [
   '-Wno-ignored-qualifiers',
-  '-Wno-missing-template-keyword',
   '-Wno-sign-compare',
   '-Wno-overloaded-virtual',
   '-Wno-unused-parameter',
   '-Wno-vla',
+] + extra_toolchain_args
+
+add_project_arguments(
+  project_args,
   language: ['cpp'],
 )
 


### PR DESCRIPTION
Three commits here:

* `clang` and `gcc` support an overlapping but not entirely identical set of command line switches.  Two of the ones we use to suppress warnings in `gcc` are not known to `clang`, which cause compilation to fail.  `clang` also warns about something `gcc` does not, and we need a different warning suppression switch that is not known to `gcc`.  The first commit adjusts the meson build configuration to be slightly more compiler-aware and to do the right thing with `clang`. 
* on macOS, `off_t` is a `long long`.  %zd is for use with size_t, but size_t may still be just `long`, so clang warns about the format strings.  The easiest thing to do appears to be to just upcast all the places we'd print an off_t to be `long long` and use the `%lld` format string instead.
* clang warns on any usage of the deprecated `sprintf` and strongly recommends you use `snprintf` instead, so I just changed the one instance (generating a filename) to use `snprintf` instead.